### PR TITLE
GAME-43

### DIFF
--- a/BioDude/Assets/Scenes/Menu.unity
+++ b/BioDude/Assets/Scenes/Menu.unity
@@ -1177,7 +1177,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.12541202, y: -0.0000024987587}
+  m_AnchoredPosition: {x: -0.12541202, y: 0.000010861124}
   m_SizeDelta: {x: 0.25, y: 0}
   m_Pivot: {x: 0.00000010430813, y: 1}
 --- !u!114 &678707798
@@ -1254,7 +1254,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.10004421, y: -0.000015271466}
+  m_AnchoredPosition: {x: 0.100044206, y: -0.00000001268927}
   m_SizeDelta: {x: -4.399994, y: 0}
   m_Pivot: {x: 0.000000044703484, y: 0.99999964}
 --- !u!114 &742021865

--- a/BioDude/Assets/Scripts/GUI scripts/Achievement.cs
+++ b/BioDude/Assets/Scripts/GUI scripts/Achievement.cs
@@ -155,11 +155,12 @@ public class Achievement : MonoBehaviour
     {
         unlocked = value;
 
-        int tmpPoints = PlayerPrefs.GetInt("Points");
 
-        PlayerPrefs.SetInt("Points", tmpPoints += points);
         if (value == true)
         {
+            int tmpPoints = PlayerPrefs.GetInt("Points");
+
+            PlayerPrefs.SetInt("Points", tmpPoints += points);
             PlayerPrefs.SetInt(name, 1);
         }
         else
@@ -183,7 +184,7 @@ public class Achievement : MonoBehaviour
 
         if (unlocked)
         {
-            AchievementManager.Instance.textPoints.text = "Points: " + PlayerPrefs.GetInt("Points");
+            AchievementManager.Instance.textPoints.text = "Points: " + PlayerPrefs.GetInt("Points").ToString();
             currentProgression = PlayerPrefs.GetInt("Progression" + Name);
             achievementRef.GetComponent<Image>().sprite = AchievementManager.Instance.unlockedSprite;
         }

--- a/BioDude/Assets/Scripts/GUI scripts/AchievementManager.cs
+++ b/BioDude/Assets/Scripts/GUI scripts/AchievementManager.cs
@@ -123,7 +123,7 @@ public class AchievementManager : MonoBehaviour
         {
             GameObject achievement = (GameObject)Instantiate(visualAchievement);
             SetAchievementInfo("EarnAchievementCanvas", achievement, title);
-            textPoints.text = "Points: " + PlayerPrefs.GetInt("Points");
+            textPoints.text = "Points: " + PlayerPrefs.GetInt("Points").ToString();
             StartCoroutine(FadeAchievement(achievement));
         }
     }


### PR DESCRIPTION
fixed a bug, where points would double, because a method CheckProgress() would be called before achievement is earned. Now Points are gained only if achievement is actually earned and not if progress is checked. All of that in file: Achievement.cs